### PR TITLE
fix: corrected a typo in today.json

### DIFF
--- a/today.json
+++ b/today.json
@@ -15,7 +15,7 @@
             "Take your dog out."
         ],
         "frequency": "Annual",
-        "refernce": "https://nationaltoday.com/national-dog-day/"
+        "reference": "https://nationaltoday.com/national-dog-day/"
     },
     {
         "date": [
@@ -33,6 +33,6 @@
             ""
         ],
         "frequency": "Annual",
-        "refernce": "https://en.wikipedia.org/wiki/International_Workers%27_Day"
+        "reference": "https://en.wikipedia.org/wiki/International_Workers%27_Day"
     }
 ]


### PR DESCRIPTION
I've fixed a typo (refernce to **reference**) in today.json code. Same issue as in README.md